### PR TITLE
Add host support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,11 @@
 redis-collectd
 ==============
 
-Redis plugin for collectd. Wrote this to learn Go - it could probably use a refactor.
+Redis plugin for collectd.
+
+Based on https://github.com/jamiealquiza/redis-collectd, but adding the host so we can collect stats per host and port.
 
 ### How it works
-
-The plugin expects exactly two arguments in the following order:
-
-<pre>
-./redis-collectd 127.0.0.1 6379
-</pre>
 
 Since this is used as a collectd plugin, it pulls metrics on a best-effort basis and will fail silent with incorrect command line arguments, failed connections to Redis, and so forth.
 
@@ -21,15 +17,15 @@ Build / place binary in your plugin path. Example:
 <pre>
 go build redis-collectd.go
 cp redis-collectd /opt/collectd/lib/collectd/
-chown collectd:collectd /opt/collectd/lib/collectd/redis-collectd
+chown root:root /opt/collectd/lib/collectd/redis-collectd
 </pre>
 
 In collectd.conf:
 <pre>
 LoadPlugin exec
-&lt;Plugin exec&gt;
-  Exec "collectd" "/opt/collectd/lib/collectd/redis-collectd" "127.0.0.1" "6379"
-&lt;/Plugin&gt;
+<Plugin exec>
+  Exec "nobody" "/opt/collectd/lib/collectd/redis-collectd" "127.0.01.1" "6379"
+</Plugin>
 </pre>
 
 ### Example output


### PR DESCRIPTION
Hi, 

I need to monitor several Redis that are in a Cluster and are running inside a Docker container.

Each instance has more than 1 Pod on the same IP address but with a different port. The Pod is also running in different instances, but always in the same port. So I needed identify the instance has "host-port" and not only using the "port".

Example:
```
./redis-collectd 127.0.0.1 7100  , this is "redis-1"
./redis-collectd 127.0.0.2 7100  , this is "redis-1"
./redis-collectd 127.0.0.3 7100  , this is "redis-1"

./redis-collectd 127.0.0.1 7230  , this is "redis-2"
./redis-collectd 127.0.0.2 7230  , this is "redis-2"
./redis-collectd 127.0.0.3 7230  , this is "redis-2"
```
This tells me that the "redis-2" Pod is using always the port 7230, no matter in what instance he is running.

If I run this from 172.100.100.1, the values formatted will be:
```
formatted["PUTVAL "172.100.100.1"/redis-**127.0.0.1-7100**/counter-"+k] = v
formatted["PUTVAL "172.100.100.1"/redis-**127.0.0.2-7100**/counter-"+k] = v
formatted["PUTVAL "172.100.100.1"/redis-**127.0.0.3-7100**/counter-"+k] = v

formatted["PUTVAL "172.100.100.1"/redis-**127.0.0.1-7230**/counter-"+k] = v
formatted["PUTVAL "172.100.100.1"/redis-**127.0.0.2-7230**/counter-"+k] = v
formatted["PUTVAL "172.100.100.1"/redis-**127.0.0.3-7230**/counter-"+k] = v
```

I also added ```time.Sleep(58 * time.Second)```, because I only need to collect stats per minute, and the plugin collects every second. This sure is not the best way to do this, so please make it pretty and efficient.

#### Nice to have:

* Collect metric in a different time range from every second.

* It will also be nice if we can choose only some metrics, perhaps load "statsFilter" array from a different file.


Thanks,
Mario